### PR TITLE
Fix typo in queries.sh

### DIFF
--- a/queries.sh
+++ b/queries.sh
@@ -28,7 +28,7 @@ echo
 echo -e "\nWinner of the 2018 tournament team name:"
 echo
 
-echo -e "\nList of teams who played in the 2014 'Eight-final' round:"
+echo -e "\nList of teams who played in the 2014 'Eighth-Final' round:"
 echo
 
 echo -e "\nList of unique winning team names in the whole data set:"


### PR DESCRIPTION
Fix typo in `queries.sh` challenge where `Eighth-Final` text was not matching the `games.csv` text.