### PR TITLE
 #opponent_id typo fix: learn-world-cup-database #45674

### DIFF
--- a/tutorial.json
+++ b/tutorial.json
@@ -69,7 +69,7 @@
             "You should **connect to your worldcup database** and then create `teams` and `games` tables",
             "Your `teams` table should have a `team_id` column as its primary key and a `name` column that has to be `UNIQUE`",
             "Your `games` table should have a `game_id` column as its primary key, a `year` column of type `INT`, and a `round` column of type `VARCHAR`",
-            "Your `games` table should have `winner_id` and `opponenent_id` foreign key columns that each reference `team_id` from the `teams` table",
+            "Your `games` table should have `winner_id` and `opponent_id` foreign key columns that each reference `team_id` from the `teams` table",
             "Your `games` table should have `winner_goals` and `opponent_goals` columns that are type `INT`",
             "All of your columns should have the `NOT NULL` constraint",
             "Your two script (`.sh`) files should have executable permissions. Other tests involving these two files will fail until permissions are correct. When these permissions are enabled, the tests will take significantly longer to run",


### PR DESCRIPTION
            "Your `games` table should have `winner_id` and `opponent_id` foreign key columns that each reference `team_id` from the `teams` table",

Changed so instructions won't lead users to error
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45674

<!-- Feel free to add any additional description of changes below this line -->
